### PR TITLE
feat: add `directedOn_union_iff` with extra lemmas

### DIFF
--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -149,6 +149,61 @@ theorem or_of_directedOn_union' [Preorder α] {s t : Set α}
     · aesop
     · exact .inr ⟨h, ht⟩
 
+theorem DirectedOn.of_isCofinalFor [Preorder α] {s t : Set α}
+    (hd : DirectedOn (· ≤ ·) t) (hst : s ⊆ t) (hc : IsCofinalFor t s) :
+    DirectedOn (· ≤ ·) s := by
+  intro x hx y hy
+  obtain ⟨z,hz,hxz,hyz⟩ := hd x (hst hx) y (hst hy)
+  obtain ⟨w,hw,hzw⟩ := hc hz
+  exact ⟨w, hw, hxz.trans hzw, hyz.trans hzw⟩
+
+theorem IsCofinalFor.union_left [Preorder α] {s t : Set α} (hc : IsCofinalFor s t) :
+    IsCofinalFor (s ∪ t) t := by
+  intro a ha
+  rcases ha with has | hat
+  · exact hc has
+  · exact ⟨a, hat, le_rfl⟩
+
+theorem or_of_isCofinalFor_of_directedOn_union [Preorder α] {s t : Set α}
+    (h : DirectedOn (· ≤ ·) (s ∪ t)) : IsCofinalFor t s ∨ IsCofinalFor s t := by
+  by_cases hts : IsCofinalFor t s
+  · exact .inl hts
+  · right
+    intro x hx
+    simp only [IsCofinalFor, not_forall, not_exists, not_and] at hts
+    obtain ⟨y, hy, hys⟩ := hts
+    obtain ⟨z, hz, hxz, hyz⟩ := h x (.inl hx) y (.inr hy)
+    rcases hz with hzs | hzt
+    · exfalso
+      exact hys z hzs hyz
+    · exact ⟨z, hzt, hxz⟩
+
+theorem directedOn_union_iff [Preorder α] {s t : Set α} : DirectedOn (· ≤ ·) (s ∪ t) ↔
+    (DirectedOn (· ≤ ·) s ∧ IsCofinalFor t s) ∨ (DirectedOn (· ≤ ·) t ∧ IsCofinalFor s t) := by
+  constructor
+  · intro h
+    rcases or_of_isCofinalFor_of_directedOn_union h with hts | hst
+    · left
+      have hs' : IsCofinalFor (s ∪ t) s := by
+        simpa [Set.union_comm] using hts.union_left
+      exact ⟨DirectedOn.of_isCofinalFor h Set.subset_union_left hs', hts⟩
+    · right
+      exact ⟨DirectedOn.of_isCofinalFor h Set.subset_union_right hst.union_left, hst⟩
+  · intro h
+    rcases h with ⟨hs, hts⟩ | ⟨ht, hst⟩
+    · have hs' : IsCofinalFor (s ∪ t) s := by
+        simpa [Set.union_comm] using hts.union_left
+      intro x hx y hy
+      obtain ⟨x', hx', hxx'⟩ := hs' hx
+      obtain ⟨y', hy', hyy'⟩ := hs' hy
+      obtain ⟨z, hz, hx'z, hy'z⟩ := hs x' hx' y' hy'
+      exact ⟨z, Or.inl hz, hxx'.trans hx'z, hyy'.trans hy'z⟩
+    · intro x hx y hy
+      obtain ⟨x', hx', hxx'⟩ := hst.union_left hx
+      obtain ⟨y', hy', hyy'⟩ := hst.union_left hy
+      obtain ⟨z, hz, hx'z, hy'z⟩ := ht x' hx' y' hy'
+      exact ⟨z, Or.inr hz, hxx'.trans hx'z, hyy'.trans hy'z⟩
+
 theorem Std.Total.directed [Std.Total r] (f : ι → α) : Directed r f := fun i j =>
   Or.casesOn (total_of r (f i) (f j)) (fun h => ⟨j, h, refl _⟩) fun h => ⟨i, refl _, h⟩
 


### PR DESCRIPTION
Prove `directedOn_union_iff ` in #37304.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
I just aksed an AI agent to generate names for these lemmas—please feel free to change them.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
